### PR TITLE
Add support for dynamically pulling event parameters and adding them to the flat_events table as columns

### DIFF
--- a/cf/main.py
+++ b/cf/main.py
@@ -660,6 +660,9 @@ def flatten_ga_data(event, context):
                                                 table_name=input_event.table_name,
                                                 date_shard=input_event.table_date_shard)
 
+        # set dynamic flat events schema
+        ga_source.set_dynamic_flat_events_schema()
+
         # EVENT_PARAMS
         if input_event.flatten_nested_table(nested_table=os.environ["EVENT_PARAMS"]):
             ga_source.run_query_job(query=ga_source.get_event_params_query(), table_type="flat_event_params",

--- a/cfconfigbuilder/main.py
+++ b/cfconfigbuilder/main.py
@@ -160,8 +160,8 @@ FROM (
                 }}})
         return json_config_updated
 
-    def add_output_params_into_config(self, json_config, output_sharded=True,
-                                      output_partitioned=False):
+    def add_output_params_into_config(self, json_config, output_sharded=False,
+                                      output_partitioned=True):
         """
         Adds cfintraday config params to config file.
 


### PR DESCRIPTION
This is all internally handled. The only external consideration is that event parameters pivoted to fields will contain the suffic `_ep` to help avoid potential column name collisions from event fields (especially when considering custom parameters may get included).